### PR TITLE
Code to switch to new PagerDuty Bridge application

### DIFF
--- a/config.js
+++ b/config.js
@@ -27,6 +27,8 @@ module.exports = {
     recommendationUrl: process.env.RECOMMENDATION_URL_DEV,
     token: process.env.API_TOKEN_DEV,
     pollingDelay: process.env.POLLING_DELAY_DEV || pollingDelay,
+    useNewPDBridge: process.env.USE_NEW_PD_BRIDGE_DEV || false,
+    pdBridgeUrl: process.env.PD_BRIDGE_URL_DEV || null,
   },
   perf: {
     refocusUrl: process.env.REFOCUS_URL_PERF,
@@ -34,6 +36,8 @@ module.exports = {
     recommendationUrl: process.env.RECOMMENDATION_URL_PERF,
     token: process.env.API_TOKEN_PERF,
     pollingDelay: process.env.POLLING_DELAY_PERF || pollingDelay,
+    useNewPDBridge: process.env.USE_NEW_PD_BRIDGE_PERF || false,
+    pdBridgeUrl: process.env.PD_BRIDGE_URL_PERF || null,
   },
   sandbox: {
     refocusUrl: process.env.REFOCUS_URL_SANDBOX,
@@ -41,6 +45,8 @@ module.exports = {
     recommendationUrl: process.env.RECOMMENDATION_URL_SANDBOX,
     token: process.env.API_TOKEN_SANDBOX,
     pollingDelay: process.env.POLLING_DELAY_SANDBOX || pollingDelay,
+    useNewPDBridge: process.env.USE_NEW_PD_BRIDGE_SANDBOX || false,
+    pdBridgeUrl: process.env.PD_BRIDGE_URL_SANDBOX || null,
   },
   production: {
     refocusUrl: process.env.REFOCUS_URL_PROD,
@@ -48,6 +54,8 @@ module.exports = {
     recommendationUrl: process.env.RECOMMENDATION_URL_PROD,
     token: process.env.API_TOKEN_PROD,
     pollingDelay: process.env.POLLING_DELAY_PROD || pollingDelay,
+    useNewPDBridge: process.env.USE_NEW_PD_BRIDGE_PROD || false,
+    pdBridgeUrl: process.env.PD_BRIDGE_URL_PROD || null,
   },
 };
 

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function getServices(offset) {
     if (!result.body) return {};
     // Feature Flag
     const resBody = USING_NEW_PD_BRIDGE ? result.body : result.body.services;
-    services = services.concat(resBody);
+    if (resBody && resBody.length) services = services.concat(resBody);
     // Feature Flag
     if (!USING_NEW_PD_BRIDGE && result.body.more) {
       return getServices(offset + SERVICES_LIMIT);

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ function pdIncidentDetail(id) {
  */
 function getServices(offset) {
   return pdServices(offset).then((result) => {
+    if (!result.body) return {};
     // Feature Flag
     const resBody = USING_NEW_PD_BRIDGE ? result.body : result.body.services;
     services = services.concat(resBody);

--- a/web/index.js
+++ b/web/index.js
@@ -305,11 +305,11 @@ function init() {
       currentTemplate = _template ? _template.value : defaultTemplate;
       currentRecommendations = _recommendations ?
         JSON.parse(_recommendations.value) : [];
-
-      if (!_services || !_template || !_variables || !_recommendations) {
+      if (!_services || _.isEmpty(currentServices) || !_template||
+       !_variables|| !_recommendations) {
         bdk.findRoom(roomId)
           .then((res) => {
-            if (!_services || _.isEmpty(_services)) {
+            if (!_services || _.isEmpty(currentServices)) {
               if (res.body.settings && res.body.settings.onCallBotServices) {
                 currentServices = res.body.settings.onCallBotServices;
               }


### PR DESCRIPTION
The changes included in this PR allow the application to retrieve PagerDuty service information from our new bridge application instead of hitting the PagerDuty API every time. 

- `index.js` - added feature flagged code to query the pagerduty API or the new bridge app.

- `web/index.js` - adjusted the logic to get services to hopefully avoid the infinite spinning issue.