### PR TITLE
Pass correct service array to page action

### DIFF
--- a/web/components/App.jsx
+++ b/web/components/App.jsx
@@ -154,6 +154,7 @@ class App extends React.Component{
 
   pageGroup(services) {
     if (services.length > ZERO) {
+      const serviceIds = services.map((service) => service.value);
       const serviceReq = {
         'name': 'pagerServices',
         'botId': botName,
@@ -162,7 +163,7 @@ class App extends React.Component{
         'parameters': [
           {
             'name': 'services',
-            'value': services,
+            'value': serviceIds,
           },
           {
             'name': 'message',


### PR DESCRIPTION
In my previous PR I had adjusted some of the code in the 'page' button, this led to an object being passed into the pageGroup function rather than an array of values.

Added a map to recreate this array from the object.