### PR TITLE
Fix Toast Bug

### DIFF
--- a/web/components/App.jsx
+++ b/web/components/App.jsx
@@ -20,6 +20,7 @@ const env = require('../../config.js').env;
 const config = require('../../config.js')[env];
 const bdk = require('@salesforce/refocus-bdk')(config, botName);
 const ZERO = 0;
+const TOAST_TIMEOUT = 3000;
 
 class App extends React.Component{
   constructor(props){
@@ -53,6 +54,8 @@ class App extends React.Component{
   componentDidUpdate(prevProps) {
     if (this.props.response && this.state.waiting) {
       this.setState({ response: this.props.response, waiting: false });
+      this.showToast(this.props.response.statusText);
+      setTimeout(this.closeToast, TOAST_TIMEOUT);
     }
     if (prevProps.recommendations.length !== this.props.recommendations.length) {
       this.pageInstrumentBuilder
@@ -60,8 +63,12 @@ class App extends React.Component{
     }
   }
 
+  showToast(message) {
+    this.setState({ toastMessage: message });
+  }
+
   closeToast(){
-    this.setState({ response: null });
+    this.setState({ toastMessage: null });
   }
 
   getRoomCreatedDate() {
@@ -187,7 +194,7 @@ class App extends React.Component{
   }
 
   render(){
-    const { selectedTeams, selectOpen } = this.state;
+    const { selectedTeams, selectOpen, toastMessage } = this.state;
     const { services, incidents, recommendations } = this.props;
     const options = [];
     Object.keys(services).forEach((key) => {
@@ -215,10 +222,9 @@ class App extends React.Component{
           </div>
         ) : (
           <div>
-            { this.state.response &&
+            { toastMessage &&
               <ToastMessage
-                message={ this.state.response.statusText }
-                removeToastHandler={this.closeToast}
+                message={ toastMessage }
               />
             }
             <div className={selectOpen ? `${gridCSS} select-open` : gridCSS}>

--- a/web/components/App.jsx
+++ b/web/components/App.jsx
@@ -8,13 +8,13 @@
 
 import PropTypes from 'prop-types';
 import Select from 'react-select';
+import ToastMessage from './ToastMessage.jsx';
 import './overrides.css';
 import isEqual from 'lodash/isEqual';
 import PageInstrumentBuilder from './PageInstrumentBuilder';
 import PageInstrumentStore from './PageInstrumentStore';
 
 const React=require('react');
-const ToastMessage=require('./ToastMessage.jsx');
 const botName = require('../../package.json').name;
 const env = require('../../config.js').env;
 const config = require('../../config.js')[env];
@@ -51,11 +51,8 @@ class App extends React.Component{
 
 
   componentDidUpdate(prevProps) {
-    if (this.props.response) {
-      if (this.state.waiting) {
-        this.setState({ response: this.props.response });
-      }
-      this.setState({ waiting: false });
+    if (this.props.response && this.state.waiting) {
+      this.setState({ response: this.props.response, waiting: false });
     }
     if (prevProps.recommendations.length !== this.props.recommendations.length) {
       this.pageInstrumentBuilder

--- a/web/components/ToastMessage.jsx
+++ b/web/components/ToastMessage.jsx
@@ -30,8 +30,9 @@ class ToastMessage extends React.Component {
               <div className="slds-notify__content">
                 <h2 className="slds-text-heading_small">{ message }</h2>
               </div>
-              <button className="slds-button slds-button_icon slds-notify__close slds-button_icon-inverse"
-                onClick={() => this.hide()} title="Close">
+              <button className="slds-button slds-button_icon
+                slds-notify__close slds-button_icon-inverse"
+              onClick={() => this.hide()} title="Close">
                 X
               </button>
             </div>

--- a/web/components/ToastMessage.jsx
+++ b/web/components/ToastMessage.jsx
@@ -14,8 +14,8 @@ class ToastMessage extends React.Component{
   constructor(props){
     super(props);
     this.state={
-      message: props.message,
-      show: false,
+      show: true,
+      interval: setInterval(() => this.closeToast(), TIMEOUT)
     };
     this.closeToast=this.closeToast.bind(this);
   }
@@ -27,25 +27,14 @@ class ToastMessage extends React.Component{
     }
   }
 
-  componentDidMount() {
-    this.setState({ message: this.props.message });
-    this.setState({ show: true });
-    this.interval = setInterval(() => this.closeToast(), TIMEOUT);
-  }
-
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  /* eslint-disable react/no-deprecated */
-  componentWillReceiveProps(nextProps) {
-    this.setState({ message: nextProps.message });
-    this.setState({ show: true });
-  }
-
   /* eslint-disable max-len */
   render(){
-    const { message, show } = this.state;
+    const { message } = this.props;
+    const { show } = this.state;
     return (
       <div className={show ? '' : 'slds-hide'} style={{ width: '100%' }}>
         <div className="slds-region_narrow slds-is-relative">

--- a/web/components/ToastMessage.jsx
+++ b/web/components/ToastMessage.jsx
@@ -8,35 +8,22 @@
 
 const React=require('react');
 import PropTypes from 'prop-types';
-const TIMEOUT = 3000; // ms
 
-class ToastMessage extends React.Component{
-  constructor(props){
+class ToastMessage extends React.Component {
+  constructor(props) {
     super(props);
-    this.state={
-      show: true,
-      interval: setInterval(() => this.closeToast(), TIMEOUT)
+    this.state = {
+      isHidden: false
     };
-    this.closeToast=this.closeToast.bind(this);
   }
-
-  closeToast(){
-    if (this.props.removeToastHandler) {
-      this.setState({ show: false });
-      this.props.removeToastHandler();
-    }
+  hide() {
+    this.setState({ isHidden: true });
   }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  /* eslint-disable max-len */
-  render(){
+  render() {
     const { message } = this.props;
-    const { show } = this.state;
+    const { isHidden } = this.state;
     return (
-      <div className={show ? '' : 'slds-hide'} style={{ width: '100%' }}>
+      <div className={isHidden ? 'slds-hide' : ''} style={{ width: '100%' }}>
         <div className="slds-region_narrow slds-is-relative">
           <div className="slds-notify_container slds-is-absolute">
             <div className="slds-notify slds-notify_toast slds-theme_info slds-size_3-of-4">
@@ -44,7 +31,7 @@ class ToastMessage extends React.Component{
                 <h2 className="slds-text-heading_small">{ message }</h2>
               </div>
               <button className="slds-button slds-button_icon slds-notify__close slds-button_icon-inverse"
-                onClick={() => this.closeToast()} title="Close">
+                onClick={() => this.hide()} title="Close">
                 X
               </button>
             </div>
@@ -54,7 +41,6 @@ class ToastMessage extends React.Component{
     );
   }
 }
-
 ToastMessage.propTypes={
   message: PropTypes.string,
   removeToastHandler: PropTypes.func,


### PR DESCRIPTION
Another regression introduced in the instrument-paging PR. The state update to show the toast was crashing the frontend after a page was sent out. 

- ### web/components/App.jsx
   - Changed componentDidUpdate to avoid state update loop. (Consolidated calls to setState() so waiting was set to false immediately) 

   - Added `showToast` function and modified the functionality behind clearing the toast, the old functionality meant that the toast component would call the method to remove itself. Now the timing logic is all in `App.jsx` and the `x` button in the toast handler simply hides it. 

- ### web/components/ToastMessage.jsx
   - Simplified the ToastMessage class - as mentioned above, replaced passed down function with `hide` which makes it invisible until the above component removes it after the timeout 