### PR TITLE
Incorrect Incidents Parsing

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -139,7 +139,8 @@ function handleData(data) {
     handleDataAction(data);
   }
 
-  const incidents = _incidentLogs ? _incidentLogs.incidents : [];
+  const incidents = _incidentLogs && _incidentLogs.value ?
+    JSON.parse(_incidentLogs.value).incidents : [];
   renderUI(currentServices, currentMessage, null, incidents);
 }
 


### PR DESCRIPTION
Another regression :( 

- When I updated `App.jsx` to use props instead of copying props into state it exposed a bug in index.js which hadn't been having an effect. The object _incidentLogs wasn't being unwrapped correctly. 

