### PR TITLE
Fix TTE end time being overridden when there are multiple ack entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.2.3 Added instrumentation for recommendation model training.
 * 1.2.4 Fixed pageInstrument/incidentLog bugs and added failover support.
 * 1.2.5 TTE definition changed. TTE ends when PD is acknowledged or resolved.
+* 1.2.6 Fix TTE end time gets overridden by latter ack entry when there are multiple ack entries.

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.2.3 Added instrumentation for recommendation model training.
 * 1.2.4 Fixed pageInstrument/incidentLog bugs and added failover support.
 * 1.2.5 TTE definition changed. TTE ends when PD is acknowledged or resolved.
-* 1.2.6 Fix TTE end time gets overridden by latter ack entry when there are multiple ack entries.
+* 1.2.6 Fixed TTE end time getting overridden by latter ack entry when there are multiple ack entries.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Oncall-Bot",
   "displayName": "Oncall",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A bot for PagerDuty integration",
   "url": "https://git.soma.salesforce.com/Refocus-Bots/Oncall-Bot",
   "scripts": {
@@ -24,6 +24,7 @@
     "jsforce": "^1.9.2",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
+    "moment": "^2.27.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/tests/utils/tte.js
+++ b/tests/utils/tte.js
@@ -12,6 +12,7 @@
 /* eslint camelcase: 0 */
 const expect = require('chai').expect;
 const createTTE = require('../../utils/tte.js').createTTE;
+const compare = require('../../utils/tte.js').compare;
 
 const testTeamData = 'TestTeam';
 const testPdData = {};
@@ -35,6 +36,7 @@ describe('tte.js >', () => {
       const tte = createTTE('aa', testTeamData, testPdData);
       expect(tte).to.deep.equal(expected);
     });
+
     it('should return a single tte acknowledge_log_entry', () => {
       const expected = {
         id: 'ab',
@@ -54,6 +56,7 @@ describe('tte.js >', () => {
       const tte = createTTE('ab', testTeamData, testPdData);
       expect(tte).to.deep.equal(expected);
     });
+
     it('should return a single tte resolve_log_entry', () => {
       const expected = {
         id: 'ab',
@@ -73,6 +76,7 @@ describe('tte.js >', () => {
       const tte = createTTE('ab', testTeamData, testPdData);
       expect(tte).to.deep.equal(expected);
     });
+
     it('should return a single tte if both ack/resolve entry exist', () => {
       const expected = {
         id: 'ab',
@@ -95,6 +99,91 @@ describe('tte.js >', () => {
         }];
       const tte = createTTE('ab', testTeamData, testPdData);
       expect(tte).to.deep.equal(expected);
+    });
+
+    it('should return tte with end time of the first ack entry ' +
+      'if multiple ack entries exist', () => {
+      const expected = {
+        id: 'ab',
+        start: '2019-09-04T09:15:41Z',
+        end: '2019-09-04T09:16:00Z',
+        team: 'TestTeam'
+      };
+      testPdData.body.log_entries = [
+        {
+          type: 'notify_log_entry',
+          created_at: '2019-09-04T09:15:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:16:30Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:16:15Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:16:00Z',
+        },
+        {
+          type: 'resolve_log_entry',
+          created_at: '2019-09-04T09:20:41Z',
+        }];
+      const tte = createTTE('ab', testTeamData, testPdData);
+      expect(tte).to.deep.equal(expected);
+    });
+  });
+
+  describe('Test Compare function', () => {
+    it('should return end time null with no acknowledge/resolve_log_entry', () => {
+      const entries = [
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:15:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:13:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:11:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:16:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:13:41Z',
+        },
+      ];
+
+      const expected = [
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:11:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:13:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:13:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:15:41Z',
+        },
+        {
+          type: 'acknowledge_log_entry',
+          created_at: '2019-09-04T09:16:41Z',
+        },
+      ];
+      const actual = entries.sort(compare);
+      expect(actual).to.deep.equal(expected);
     });
   });
 });

--- a/tests/utils/tte.js
+++ b/tests/utils/tte.js
@@ -136,7 +136,7 @@ describe('tte.js >', () => {
   });
 
   describe('Test Compare function', () => {
-    it('should return end time null with no acknowledge/resolve_log_entry', () => {
+    it('should sort the list of entries by created_at time ascendingly', () => {
       const entries = [
         {
           type: 'acknowledge_log_entry',

--- a/utils/tte.js
+++ b/utils/tte.js
@@ -11,7 +11,23 @@
  *
  * This code handles will creation of tte from given data
  */
+const moment = require('moment');
 const ZERO = 0;
+
+/**
+ * The compare function for sorting PD log entries by created date
+ * @param entry1 - log entry 1
+ * @param entry2 - log entry 2
+ * @returns {number}
+ */
+function compare(entry1, entry2) {
+  if (moment(entry1.created_at) < moment(entry2.created_at)) {
+    return -1;
+  } else if (moment(entry1.created_at) > moment(entry2.created_at)) {
+    return 1;
+  }
+  return 0;
+}
 
 /**
  * Create TTE
@@ -26,7 +42,8 @@ function createTTE(id, team, pdData) {
   const notify = entries
     .filter((entry) => entry.type === 'notify_log_entry')[ZERO];
   const ack = entries
-    .filter((entry) => entry.type === 'acknowledge_log_entry')[ZERO];
+    .filter((entry) => entry.type === 'acknowledge_log_entry')
+    .sort(compare)[ZERO];
   const resolve = entries
     .filter((entry) => entry.type === 'resolve_log_entry')[ZERO];
 
@@ -46,5 +63,6 @@ function createTTE(id, team, pdData) {
 }
 
 module.exports = {
-  createTTE
+  createTTE,
+  compare,
 };

--- a/utils/tte.js
+++ b/utils/tte.js
@@ -16,8 +16,8 @@ const ZERO = 0;
 
 /**
  * The compare function for sorting PD log entries by created date
- * @param entry1 - log entry 1
- * @param entry2 - log entry 2
+ * @param {Object} entry1 - log entry 1
+ * @param {Object} entry2 - log entry 2
  * @returns {number}
  */
 function compare(entry1, entry2) {
@@ -37,7 +37,8 @@ function compare(entry1, entry2) {
  * @returns {Object} - A tte
  */
 function createTTE(id, team, pdData) {
-  if (!pdData || !pdData.body || !pdData.body.log_entries) return null;
+  // eslint-disable-next-line camelcase
+  if (!pdData?.body?.log_entries) return null;
   const entries = pdData.body.log_entries;
   const notify = entries
     .filter((entry) => entry.type === 'notify_log_entry')[ZERO];


### PR DESCRIPTION
If the PD incident have multiple acknowledge entries (ack multiple times without resolve), the latter entry might override the first entry. 

Fix: 
Apply sorting to the list of entries then take the first (earliest) ack entry time as the end time. 